### PR TITLE
- modify ResultReceiver and MultipleScanReceiver in RxWifi as non-static  - make WiFiNetwork implements Parcelable

### DIFF
--- a/rxwifi/src/main/java/it/ennova/rxwifi/RxWifi.java
+++ b/rxwifi/src/main/java/it/ennova/rxwifi/RxWifi.java
@@ -31,8 +31,8 @@ import rx.Observable;
 
 public class RxWifi {
 
-    private final static ResultReceiver receiver = new ResultReceiver();
-    private final static MultipleScanReceiver multiReceiver = new MultipleScanReceiver();
+//    private final static ResultReceiver receiver = new ResultReceiver();
+//    private final static MultipleScanReceiver multiReceiver = new MultipleScanReceiver();
 
     protected final static IntentFilter filter = new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
 
@@ -41,7 +41,7 @@ public class RxWifi {
      * the networks in range of the device
      */
     public static Observable<ScanResult> from (@NonNull Context context) {
-        return receiver.startScanningFrom(context).getObservable();
+        return new ResultReceiver().startScanningFrom(context).getObservable();
     }
 
     /**
@@ -49,6 +49,6 @@ public class RxWifi {
      * scheduler, so that it doesn't block the UI
      */
     public static Observable<List<ScanResult>> from(@NonNull Context context, int times) {
-        return multiReceiver.scan(context, times);
+        return new MultipleScanReceiver().scan(context, times);
     }
 }

--- a/rxwifi/src/main/java/it/ennova/rxwifi/WiFiNetwork.java
+++ b/rxwifi/src/main/java/it/ennova/rxwifi/WiFiNetwork.java
@@ -18,6 +18,8 @@
 
 package it.ennova.rxwifi;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import it.ennova.rxwifi.internals.WifiFrequency;
@@ -26,7 +28,7 @@ import it.ennova.rxwifi.internals.WifiFrequency;
  * This class represents the minimum amount of information needed for showing the different networks
  * on a graph
  */
-public class WiFiNetwork {
+public class WiFiNetwork implements Parcelable {
 
     private final String SSID;
     private final String BSSID;
@@ -96,4 +98,41 @@ public class WiFiNetwork {
                 ", frequency=" + frequency +
                 '}';
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.SSID);
+        dest.writeString(this.BSSID);
+        dest.writeString(this.capabilities);
+        dest.writeInt(this.channel);
+        dest.writeInt(this.strength);
+        dest.writeInt(this.frequency == null ? -1 : this.frequency.ordinal());
+    }
+
+    protected WiFiNetwork(Parcel in) {
+        this.SSID = in.readString();
+        this.BSSID = in.readString();
+        this.capabilities = in.readString();
+        this.channel = in.readInt();
+        this.strength = in.readInt();
+        int tmpFrequency = in.readInt();
+        this.frequency = tmpFrequency == -1 ? null : WifiFrequency.values()[tmpFrequency];
+    }
+
+    public static final Parcelable.Creator<WiFiNetwork> CREATOR = new Parcelable.Creator<WiFiNetwork>() {
+        @Override
+        public WiFiNetwork createFromParcel(Parcel source) {
+            return new WiFiNetwork(source);
+        }
+
+        @Override
+        public WiFiNetwork[] newArray(int size) {
+            return new WiFiNetwork[size];
+        }
+    };
 }


### PR DESCRIPTION
## modify ResultReceiver and MultipleScanReceiver in RxWifi as non-static

Because of static ResultReceiver and MultipleScanReceiver object in RxWifi. After the first subscribe, the later subscriber always receive the last result immediately. And at this moment, scan start, after a while the observable send the new scan result.
## make WiFiNetwork implements Parcelable

Just like android.net.wifi.ScanResult implements Parcelable, so we can put ArrayList<WiFiNetwork> in Intent object to send to ether activity.
